### PR TITLE
Add nix-shell configuration (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ neo4j-custom/neo4j_start.txt
 neo4j-custom/neo4j_stop.txt
 neo4j-custom/neo4j_import.txt
 neo4j-custom/import-files/*
+.neo4j/
 
 graphjs-results
 import.report
@@ -21,6 +22,7 @@ detection/queries/tests/output
 
 __pycache__/
 venv/
+.venv/
 
 node_modules*
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    python313
+    python313Packages.pip
+    python313Packages.virtualenv
+    neo4j
+    nodejs_24
+  ];
+
+  shellHook = ''
+    export NEO4J_HOME=$PWD/.neo4j
+    mkdir -p $NEO4J_HOME/{data,logs,conf}
+    if [ ! -f $NEO4J_HOME/conf/neo4j.conf ]; then
+      cp -r ${pkgs.neo4j}/share/neo4j/conf/* $NEO4J_HOME/conf/
+    fi
+    echo "Neo4j home is set to $NEO4J_HOME"
+
+    if [ ! -d .venv ]; then
+      virtualenv .venv
+    fi
+    source .venv/bin/activate
+  '';
+}


### PR DESCRIPTION
Automatically configures a development environment with python, nodejs, and neo4j.

If using `direnv`, simply put `use nix` in your `.envrc` file.

Closes #17 